### PR TITLE
Update: firefox hardware accularation

### DIFF
--- a/auto-tweaks-browser/usr/local/bin/firefox
+++ b/auto-tweaks-browser/usr/local/bin/firefox
@@ -63,13 +63,8 @@ else
 fi
 
 
-# Detect X11 or Wayland and run firefox with hardware acceleration
-if [ "$XDG_SESSION_TYPE" = "x11" ]
-then
-    MOZ_X11_EGL=1 MOZ_DISABLE_RDD_SANDBOX=1 LD_PRELOAD=/usr/lib/nosync-browser.so exec /usr/bin/firefox ${1+"$@"}
-else
-    MOZ_ENABLE_WAYLAND=1 MOZ_DISABLE_RDD_SANDBOX=1 LD_PRELOAD=/usr/lib/nosync-browser.so exec /usr/bin/firefox ${1+"$@"}
-fi
+# Run firefox
+LD_PRELOAD=/usr/lib/nosync-browser.so exec /usr/bin/firefox ${1+"$@"}
 
 
 


### PR DESCRIPTION
Hello,  
btw, the bug that forced us to launch Firefox with `MOZ_DISABLE_RDD_SANDBOX=1` to get hardware video acceleration (VA-API) to work was fixed in Firefox 102. Hardware acceleration will work on both X11 and Wayland without the need for `MOZ_X11_EGL` or `MOZ_ENABLE_WAYLAND`

[1751363 - VA-API: creating video snapshot fails due to RDD sandbox + Since bug 1724385 (98), VAAPI fails in general due to RDD sandbox](https://bugzilla.mozilla.org/show_bug.cgi?id=1751363)